### PR TITLE
Remove Godot License from project and fix naming bug

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,28 +1,3 @@
-"""
-# MIT License
-
-Copyright (c) 2017-2022 Godot Engine contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-"""
-
 #!/usr/bin/env python
 import os
 import sys

--- a/extension/src/register_types.h
+++ b/extension/src/register_types.h
@@ -1,7 +1,7 @@
 #ifndef SUMMATOR_REGISTER_TYPES_H
 #define SUMMATOR_REGISTER_TYPES_H
 
-void register_summator_types();
-void unregister_summator_types();
+void initialize_summator_types();
+void uninitialize_summator_types();
 
 #endif // SUMMATOR_REGISTER_TYPES_H


### PR DESCRIPTION
* Fixes a naming -bug- which didn't occur but could cause problems for template users
* Remove Godot MIT license from summator code since it changed to an Unlicense