### PR TITLE
Release Builds CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -15,13 +15,13 @@ jobs:
       matrix:
         include:
           - identifier: windows-debug
-            os: windows-2019
+            os: windows-latest
             name: 🏁 Windows Debug
             target: template_debug
             platform: windows
             arch: x86_64
           - identifier: windows-release
-            os: windows-2019
+            os: windows-latest
             name: 🏁 Windows Release
             target: template_release
             platform: windows
@@ -39,14 +39,14 @@ jobs:
             platform: macos
             arch: universal
           - identifier: linux-debug
-            os: ubuntu-18.04
+            os: ubuntu-latest
             name: 🐧 Linux Debug
             runner: ubuntu-20.04
             target: template_debug
             platform: linux
             arch: x86_64
           - identifier: linux-release
-            os: ubuntu-18.04
+            os: ubuntu-latest
             name: 🐧 Linux Release
             runner: ubuntu-20.04
             target: template_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Release
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          name: 'GDExtensionSummator'
+          path: downloads
+      - name: Display structure of downloaded files
+        run: ls -R
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{steps.download.outputs.download-path}}


### PR DESCRIPTION
* Adds CI support for direct GitHub releases. This should make it easier for others to directly download artifacts from the workflows
* Updates the OS versions of the runners to the latest